### PR TITLE
feat(price): charts, sticky best-deal widget, LLM modal, and report FABFeat/price module 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "~5.8.3",
     "vite": "^5.0.0",
     "@vue/tsconfig": "^0.7.0",
-    "vue-tsc": "^1.8.0"
+    "vue-tsc": "^1.8.0",
     "echarts": "^5.5.0" 
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vite": "^5.0.0",
     "@vue/tsconfig": "^0.7.0",
     "vue-tsc": "^1.8.0"
+    "echarts": "^5.5.0" 
   },
   "devDependencies": {}
 }

--- a/src/components/Main_home.vue
+++ b/src/components/Main_home.vue
@@ -51,6 +51,8 @@
 
     <!-- 하단 네비게이션 -->
     <BottomNav />
+    <!-- 추가된 FAB -->
+    <ReportFAB />
   </div>
 </template>
 
@@ -58,6 +60,7 @@
 import { useNavigation } from '../composables/useRouter'
 import { useAppStore } from '../stores/app'
 import BottomNav from './BottomNav.vue'
+import ReportFAB from './ReportFAB.vue'   // 기경: 추가
 
 const { goToCalendar, goToSideMenu } = useNavigation()
 const appStore = useAppStore()

--- a/src/components/PriceForecast.vue
+++ b/src/components/PriceForecast.vue
@@ -81,19 +81,33 @@ let barChart:echarts.ECharts|null = null
 function drawWeekly(){
   if(!weeklyRef.value) return
   lineChart = lineChart || echarts.init(weeklyRef.value)
+  const values = weekly.value.map(d=>d.value)
   lineChart.setOption({
+    tooltip:{ trigger:'axis' },
+    grid:{ left: 40, right: 20, top: 20, bottom: 40 },
     xAxis:{ type:'category', data: weekly.value.map(d=>d.date) },
-    yAxis:{ type:'value' },
-    series:[{ type:'line', smooth:true, areaStyle:{}, data: weekly.value.map(d=>d.value) }]
+    yAxis:{
+      type:'value',
+      min: Math.min(...values) - 50,  // 데이터 기준으로 축 좁히기
+      max: Math.max(...values) + 50
+    },
+    series:[{
+      type:'line',
+      smooth:true,
+      areaStyle:{},
+      data: values
+    }]
   })
 }
 function drawYoY(){
   if(!yoyRef.value) return
   barChart = barChart || echarts.init(yoyRef.value)
   barChart.setOption({
+    tooltip:{},
+    grid:{ left: 40, right: 20, top: 20, bottom: 40 },
     xAxis:{ type:'category', data:['작년','현재'] },
-    yAxis:{ type:'value' },
-    series:[{ type:'bar', data:[lastYearPrice.value, currentPrice.value] }]
+    yAxis:{ type:'value', min: Math.min(lastYearPrice.value,currentPrice.value)-50 },
+    series:[{ type:'bar', data:[lastYearPrice.value, currentPrice.value], barWidth:'40%' }]
   })
 }
 function resize(){ lineChart?.resize(); barChart?.resize() }
@@ -108,7 +122,7 @@ function openLLM(){
 }
 
 onMounted(()=>{
-  // dummy data
+  // 최근 14일 더미 데이터
   weekly.value = Array.from({length:14},(_,i)=>({
     date:new Date(Date.now()-(13-i)*86400000).toISOString().slice(5,10),
     value:3300+Math.round(Math.random()*200)
@@ -129,11 +143,11 @@ onUnmounted(()=> window.removeEventListener('resize', resize))
 .title{ font-size:24px; font-weight:bold; margin-bottom:1.5rem; }
 .card{ background:#1e2e36; border-radius:20px; padding:1rem; margin-bottom:1.2rem; }
 .chart-title{ font-size:14px; color:#ccc; margin-bottom:0.6rem }
-.chart-box{ background:#263843; height:160px; border-radius:12px }
+.chart-box{ background:#263843; height:300px; border-radius:12px }   /* ✅ 높이 늘림 */
 .abs-chart{ position:absolute; inset:0; }
-.label{ position:absolute; top:12px; left:12px; background:#3dd598; color:#0f1e25; padding:4px 8px; border-radius:10px; font-size:12px; font-weight:600; }
+.label{ position:absolute; top:12px; left:12px; background:#3dd598; color:#0f1e25; padding:4px 8px; border-radius:10px; font-size:12px; font-weight:600; z-index:1 }
 
-/* best deal box */
+/* best deal */
 .best-deal-box{ display:flex; justify-content:space-between; align-items:center; background:#263843; padding:12px; border-radius:12px }
 .deal-title{ font-weight:bold; margin-bottom:4px }
 .deal-price{ color:#9ca3af; font-size:13px }

--- a/src/components/PriceForecast.vue
+++ b/src/components/PriceForecast.vue
@@ -8,30 +8,53 @@
     <!-- 상단 제목 -->
     <h1 class="title">바나나 구매를<br />도와드릴게요</h1>
 
-    <!-- 1) 주간 바나나 가격 변동 추이 (라인차트) -->
+    <!-- 1) 주간 바나나 가격 변동 추이 -->
     <div class="card">
       <div class="chart-title">주간 바나나 가격 변동 추이</div>
-      <!-- 기존 placeholder 대신 차트 컨테이너 -->
-      <div ref="weeklyRef" class="bar-chart-placeholder"></div>
+      <div ref="weeklyRef" class="chart-box"></div>
     </div>
 
-    <!-- 2) 작년 대비 현재 가격 (막대차트) -->
+    <!-- 2) 작년 대비 현재 가격 -->
     <div class="card">
       <div class="chart-title">작년 대비 현재 가격</div>
-      <!-- 상단 좌측 라벨은 현재가 표시 -->
-      <div class="line-chart-placeholder">
+      <div class="chart-box relative">
         <span class="label">{{ formatWon(currentPrice) }}</span>
-        <!-- 실제 차트는 아래 div에 렌더 -->
-        <div ref="yoyRef" style="position:absolute; inset:0; border-radius:12px;"></div>
+        <div ref="yoyRef" class="abs-chart"></div>
       </div>
     </div>
 
-    <!-- 하단 네비게이션 -->
+    <!-- 3) 최저가 구매처 제안 -->
+    <div class="card">
+      <div class="chart-title">최저가 구매처 제안</div>
+      <div class="best-deal-box">
+        <div class="deal-info">
+          <p class="deal-title">{{ bestDeal.market }} · {{ bestDeal.item }} ({{ bestDeal.unit }})</p>
+          <p class="deal-price">{{ formatWon(bestDeal.price) }} · 할인 {{ bestDeal.discountPct }}%</p>
+        </div>
+        <button class="deal-btn" @click="openLLM">가격할인</button>
+      </div>
+    </div>
+
+    <!-- LLM 모달 -->
+    <div v-if="showModal" class="overlay" @click.self="showModal=false">
+      <div class="modal">
+        <header class="modal-head">
+          <h4>{{ bestDeal.market }} - {{ bestDeal.item }}</h4>
+          <button class="x" @click="showModal=false">✕</button>
+        </header>
+        <pre class="reason">{{ llmReason }}</pre>
+        <footer class="modal-foot">
+          <button class="cta" @click="showModal=false">확인</button>
+        </footer>
+      </div>
+    </div>
+
+    <!-- 하단 네비 -->
     <BottomNav />
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import * as echarts from 'echarts'
 import { useRouter } from 'vue-router'
@@ -40,131 +63,87 @@ import BottomNav from './BottomNav.vue'
 const router = useRouter()
 const goBack = () => router.go(-1)
 
-// 차트 컨테이너 ref
-const weeklyRef = ref(null)
-const yoyRef = ref(null)
+const weeklyRef = ref<HTMLDivElement|null>(null)
+const yoyRef    = ref<HTMLDivElement|null>(null)
 
-// 데이터 (더미) 생성
-const weekly = ref([])       // [{date, value}]
-const currentPrice = ref(0)  // 오늘가
-const lastYearPrice = ref(0) // 작년가(더미)
+const weekly = ref<{date:string,value:number}[]>([])
+const currentPrice = ref(0)
+const lastYearPrice = ref(0)
 
-// 포맷터
-const formatWon = (v) => `${(v || 0).toLocaleString()}원`
+const bestDeal = ref({ market:'이마트', item:'바나나', unit:'1kg', price:3980, discountPct:20 })
+const showModal = ref(false)
+const llmReason = ref('')
+const formatWon = (v:number)=> `${v.toLocaleString()}원`
 
-let lineChart = null
-let barChart  = null
+let lineChart:echarts.ECharts|null = null
+let barChart:echarts.ECharts|null = null
 
-function drawWeekly() {
-  if (!weeklyRef.value) return
+function drawWeekly(){
+  if(!weeklyRef.value) return
   lineChart = lineChart || echarts.init(weeklyRef.value)
   lineChart.setOption({
-    grid: { left: 10, right: 8, top: 10, bottom: 22 },
-    tooltip: { trigger: 'axis' },
-    xAxis: { type: 'category', data: weekly.value.map(d => d.date) },
-    yAxis: { type: 'value' },
-    series: [{
-      type: 'line',
-      smooth: true,
-      areaStyle: {},
-      data: weekly.value.map(d => d.value)
-    }]
+    xAxis:{ type:'category', data: weekly.value.map(d=>d.date) },
+    yAxis:{ type:'value' },
+    series:[{ type:'line', smooth:true, areaStyle:{}, data: weekly.value.map(d=>d.value) }]
   })
-  lineChart.resize()
 }
-
-function drawYoY() {
-  if (!yoyRef.value) return
+function drawYoY(){
+  if(!yoyRef.value) return
   barChart = barChart || echarts.init(yoyRef.value)
   barChart.setOption({
-    grid: { left: 28, right: 8, top: 14, bottom: 28 },
-    tooltip: { trigger: 'axis' },
-    xAxis: { type: 'category', data: ['작년', '현재'] },
-    yAxis: { type: 'value' },
-    series: [{
-      type: 'bar',
-      data: [lastYearPrice.value, currentPrice.value],
-      barWidth: '40%'
-    }]
+    xAxis:{ type:'category', data:['작년','현재'] },
+    yAxis:{ type:'value' },
+    series:[{ type:'bar', data:[lastYearPrice.value, currentPrice.value] }]
   })
-  barChart.resize()
+}
+function resize(){ lineChart?.resize(); barChart?.resize() }
+
+function openLLM(){
+  llmReason.value =
+`[추천 이유]
+- 가격: ${formatWon(bestDeal.value.price)} (할인 ${bestDeal.value.discountPct}%)
+- 영양: 바나나 1개당 칼륨 422mg, 비타민B6 0.4mg
+- 거리: 인근 매장 1.2km`
+  showModal.value = true
 }
 
-function handleResize() {
-  lineChart && lineChart.resize()
-  barChart && barChart.resize()
-}
-
-onMounted(() => {
-  // 최근 14일 더미 데이터
-  const base = 3500
-  weekly.value = Array.from({ length: 14 }, (_, i) => ({
-    date: new Date(Date.now() - (13 - i) * 86400000).toISOString().slice(5, 10),
-    value: Math.round(base + Math.sin(i / 2) * 120 + (Math.random() * 60 - 30))
+onMounted(()=>{
+  // dummy data
+  weekly.value = Array.from({length:14},(_,i)=>({
+    date:new Date(Date.now()-(13-i)*86400000).toISOString().slice(5,10),
+    value:3300+Math.round(Math.random()*200)
   }))
-  currentPrice.value = weekly.value[weekly.value.length - 1].value
-  // 작년가(더미) — 현재가에 ±200 정도 변동
-  lastYearPrice.value = Math.max(0, currentPrice.value + (Math.random() * 400 - 200))
+  currentPrice.value = weekly.value.at(-1)?.value || 3500
+  lastYearPrice.value = currentPrice.value + (Math.random()*400-200)
 
-  drawWeekly()
-  drawYoY()
-  window.addEventListener('resize', handleResize)
+  drawWeekly(); drawYoY()
+  window.addEventListener('resize', resize)
 })
-
-onUnmounted(() => {
-  window.removeEventListener('resize', handleResize)
-  lineChart && lineChart.dispose()
-  barChart && barChart.dispose()
-})
+onUnmounted(()=> window.removeEventListener('resize', resize))
 </script>
 
 <style scoped>
-.forecast-page {
-  background-color: #0f1e25;
-  color: white;
-  font-family: 'Noto Sans KR', sans-serif;
-  padding: 1.5rem;
-  padding-bottom: 80px;
-  min-height: 100vh;
-  box-sizing: border-box;
-}
-.header {
-  display: flex;
-  justify-content: flex-start;
-  font-size: 14px;
-  margin-bottom: 1rem;
-}
-.back-btn { color: #ffc107; cursor: pointer; }
-.title { font-size: 24px; font-weight: bold; margin-bottom: 1.5rem; line-height: 1.4; }
-.card { background-color: #1e2e36; border-radius: 20px; padding: 1rem; margin-bottom: 1.2rem; }
-.chart-title { font-size: 14px; color: #ccc; margin-bottom: 0.6rem; }
+.forecast-page{ background:#0f1e25; color:#fff; padding:1.5rem; padding-bottom:80px; min-height:100vh; }
+.header{ display:flex; margin-bottom:1rem; font-size:14px }
+.back-btn{ color:#ffc107; cursor:pointer }
+.title{ font-size:24px; font-weight:bold; margin-bottom:1.5rem; }
+.card{ background:#1e2e36; border-radius:20px; padding:1rem; margin-bottom:1.2rem; }
+.chart-title{ font-size:14px; color:#ccc; margin-bottom:0.6rem }
+.chart-box{ background:#263843; height:160px; border-radius:12px }
+.abs-chart{ position:absolute; inset:0; }
+.label{ position:absolute; top:12px; left:12px; background:#3dd598; color:#0f1e25; padding:4px 8px; border-radius:10px; font-size:12px; font-weight:600; }
 
-/* 기존 placeholder 스타일을 차트 컨테이너로 재사용 */
-.bar-chart-placeholder,
-.line-chart-placeholder {
-  background-color: #263843;
-  height: 160px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  color: #9ca3af;
-  position: relative;
-}
+/* best deal box */
+.best-deal-box{ display:flex; justify-content:space-between; align-items:center; background:#263843; padding:12px; border-radius:12px }
+.deal-title{ font-weight:bold; margin-bottom:4px }
+.deal-price{ color:#9ca3af; font-size:13px }
+.deal-btn{ background:#ffc107; color:#0f1e25; font-weight:600; padding:6px 12px; border-radius:8px; cursor:pointer }
 
-/* 현재가 라벨 */
-.line-chart-placeholder .label {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  background-color: #3dd598;
-  color: #0f1e25;
-  padding: 4px 8px;
-  border-radius: 10px;
-  font-size: 12px;
-  font-weight: 600;
-  z-index: 1;
-}
+/* modal */
+.overlay{ position:fixed; inset:0; background:rgba(0,0,0,.45); display:flex; align-items:center; justify-content:center; z-index:50 }
+.modal{ background:#0b1220; color:#e5e7eb; border-radius:16px; padding:16px; width:90%; max-width:500px }
+.modal-head{ display:flex; justify-content:space-between; margin-bottom:8px }
+.reason{ background:#0f172a; padding:12px; border-radius:8px; white-space:pre-wrap; margin-bottom:8px }
+.cta{ background:#2563eb; color:#fff; padding:6px 12px; border-radius:8px }
 </style>
 

--- a/src/components/ReportFAB.vue
+++ b/src/components/ReportFAB.vue
@@ -1,0 +1,129 @@
+<template>
+  <!-- FAB 버튼 -->
+  <button class="fab" @click="open = true">⚙️</button>
+
+  <!-- 패널 -->
+  <div v-if="open" class="drawer" @click.self="open = false">
+    <aside class="panel">
+      <header class="head">
+        <strong>저장된 일일 보고서</strong>
+        <div class="g">
+          <button class="btn" @click="genDaily">일일 생성</button>
+          <button class="x" @click="open = false">✕</button>
+        </div>
+      </header>
+
+      <ul class="list">
+        <li v-for="r in reports" :key="r.id">
+          <span>{{ r.date }} · {{ r.type === 'daily' ? '일일' : '주간' }}</span>
+          <a v-if="r.url" :href="r.url" target="_blank">다운로드</a>
+        </li>
+      </ul>
+    </aside>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+type Report = { id: string; date: string; type: 'daily' | 'weekly'; url?: string }
+
+const open = ref(false)
+const reports = ref<Report[]>([])
+
+const KEY = 'reports-demo'
+
+function load() {
+  reports.value = JSON.parse(localStorage.getItem(KEY) || '[]')
+}
+
+function save(list: Report[]) {
+  localStorage.setItem(KEY, JSON.stringify(list))
+  load()
+}
+
+function genDaily() {
+  const newReport: Report = {
+    id: crypto.randomUUID(),
+    date: new Date().toISOString().slice(0, 10),
+    type: 'daily',
+    url: '/sample.pdf'
+  }
+  save([newReport, ...reports.value])
+}
+
+onMounted(() => load())
+</script>
+
+<style scoped>
+.fab {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #111827;
+  color: #fff;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  z-index: 40;
+}
+.drawer {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 60;
+}
+.panel {
+  width: min(420px, 92vw);
+  height: 100%;
+  background: #0b1220;
+  color: #e5e7eb;
+  padding: 14px;
+}
+.head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.g {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.btn {
+  background: #1f2937;
+  color: #fff;
+  border-radius: 10px;
+  padding: 6px 10px;
+}
+.x {
+  background: transparent;
+  color: #9ca3af;
+  font-size: 18px;
+}
+.list {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  background: #0f172a;
+  border-radius: 8px;
+}
+.list a {
+  color: #60a5fa;
+}
+</style>

--- a/src/components/price/BestDealSticky.vue
+++ b/src/components/price/BestDealSticky.vue
@@ -19,7 +19,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { usePriceStore } from '@/stores/priceStore'
+import { usePriceStore } from '../../stores/priceStore'
 import DealLLMModal from './DealLLMModal.vue'
 
 const store = usePriceStore()

--- a/src/components/price/BestDealSticky.vue
+++ b/src/components/price/BestDealSticky.vue
@@ -1,0 +1,35 @@
+<template>
+  <transition name="slide-up">
+    <div v-if="visible" class="fixed bottom-4 inset-x-4 z-40">
+      <div class="flex justify-between items-center bg-yellow-300 text-black p-3 rounded-xl shadow-lg">
+        <div class="text-sm font-medium">
+          최적 구매처 제안
+          <span v-if="deal"> · {{ deal.market }} {{ deal.item }} {{ deal.price.toLocaleString() }}원</span>
+        </div>
+        <div class="flex gap-2">
+          <button class="px-3 py-1 rounded bg-black text-white" @click="openLLM">자세히</button>
+          <button class="px-3 py-1 rounded bg-white" @click="visible=false">닫기</button>
+        </div>
+      </div>
+    </div>
+  </transition>
+
+  <DealLLMModal v-if="showModal && deal" :deal="deal" :reason="store.llmReason" @close="showModal=false" />
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { usePriceStore } from '@/stores/priceStore'
+import DealLLMModal from './DealLLMModal.vue'
+
+const store = usePriceStore()
+const visible = ref(false)
+const showModal = ref(false)
+const deal = computed(()=> store.deals[0])
+
+function onScroll(){ visible.value = window.scrollY > 300 }
+async function openLLM(){ if(deal.value){ await store.refreshLLM(deal.value); showModal.value=true } }
+
+onMounted(()=> window.addEventListener('scroll', onScroll))
+onUnmounted(()=> window.removeEventListener('scroll', onScroll))
+</script>

--- a/src/components/price/DealLLMModal.vue
+++ b/src/components/price/DealLLMModal.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Deal } from '@/utils/priceService'
+import type { Deal } from '../../utils/priceService'
 defineProps<{ deal: Deal; reason: string }>()
 defineEmits(['close'])
 </script>

--- a/src/components/price/DealLLMModal.vue
+++ b/src/components/price/DealLLMModal.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" @click.self="$emit('close')">
+    <div class="bg-gray-900 text-white p-6 rounded-xl w-[90%] max-w-lg">
+      <header class="flex justify-between mb-2">
+        <h4 class="font-bold">{{ deal.market }} · {{ deal.item }}</h4>
+        <button @click="$emit('close')">✕</button>
+      </header>
+      <p class="text-sm text-gray-400 mb-3">가격: {{ deal.price.toLocaleString() }}원 · 할인 {{ deal.discountPct || 0 }}%</p>
+      <pre class="whitespace-pre-wrap text-sm bg-gray-800 p-3 rounded">{{ reason }}</pre>
+      <footer class="mt-3 text-right">
+        <button class="bg-blue-600 px-3 py-1 rounded" @click="$emit('close')">확인</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Deal } from '@/utils/priceService'
+defineProps<{ deal: Deal; reason: string }>()
+defineEmits(['close'])
+</script>

--- a/src/components/price/PriceFeatureEntry.vue
+++ b/src/components/price/PriceFeatureEntry.vue
@@ -8,7 +8,8 @@
 
 <script setup lang="ts">
 import { onMounted } from 'vue'
-import { usePriceStore } from '@/stores/priceStore'
+import { usePriceStore } from '../../stores/priceStore'
+'
 import PriceTrendCharts from './PriceTrendCharts.vue'
 import BestDealSticky from './BestDealSticky.vue'
 import ReportsFAB from './ReportsFAB.vue'

--- a/src/components/price/PriceFeatureEntry.vue
+++ b/src/components/price/PriceFeatureEntry.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="space-y-6 p-4">
+    <PriceTrendCharts />
+    <BestDealSticky />
+    <ReportsFAB />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { usePriceStore } from '@/stores/priceStore'
+import PriceTrendCharts from './PriceTrendCharts.vue'
+import BestDealSticky from './BestDealSticky.vue'
+import ReportsFAB from './ReportsFAB.vue'
+
+const store = usePriceStore()
+onMounted(()=> store.bootstrap())
+</script>

--- a/src/components/price/PriceFeatureEntry.vue
+++ b/src/components/price/PriceFeatureEntry.vue
@@ -9,7 +9,7 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { usePriceStore } from '../../stores/priceStore'
-'
+
 import PriceTrendCharts from './PriceTrendCharts.vue'
 import BestDealSticky from './BestDealSticky.vue'
 import ReportsFAB from './ReportsFAB.vue'

--- a/src/components/price/PriceTrendCharts.vue
+++ b/src/components/price/PriceTrendCharts.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="card">
+    <header class="flex justify-between mb-2">
+      <h3 class="font-bold">가격 추이 & 작년 대비</h3>
+      <small class="text-gray-400">주간 라인 + 현재/작년 막대</small>
+    </header>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div ref="lineRef" class="h-60"></div>
+      <div ref="barRef"  class="h-60"></div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as echarts from 'echarts'
+import { ref, watch, onMounted } from 'vue'
+import { usePriceStore } from '@/stores/priceStore'
+
+const store = usePriceStore()
+const lineRef = ref<HTMLDivElement|null>(null)
+const barRef  = ref<HTMLDivElement|null>(null)
+let line: echarts.ECharts|null = null
+let bar: echarts.ECharts|null = null
+
+function draw(){
+  if(lineRef.value && !line) line = echarts.init(lineRef.value)
+  if(barRef.value && !bar) bar = echarts.init(barRef.value)
+
+  line?.setOption({
+    xAxis:{ type:'category', data: store.weekly.map(d=>d.date) },
+    yAxis:{ type:'value' },
+    series:[{ type:'line', data: store.weekly.map(d=>d.value), smooth:true, areaStyle:{} }]
+  })
+
+  bar?.setOption({
+    xAxis:{ type:'category', data: store.yoy.map(d=>d.name) },
+    yAxis:{ type:'value' },
+    series:[{ type:'bar', data: store.yoy.map(d=>d.value) }]
+  })
+  line?.resize(); bar?.resize()
+}
+
+onMounted(()=>{ draw(); window.addEventListener('resize',()=>{line?.resize(); bar?.resize()}) })
+watch(()=>[store.weekly, store.yoy], draw)
+</script>

--- a/src/components/price/PriceTrendCharts.vue
+++ b/src/components/price/PriceTrendCharts.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import * as echarts from 'echarts'
 import { ref, watch, onMounted } from 'vue'
-import { usePriceStore } from '@/stores/priceStore'
+import { usePriceStore } from '../../stores/priceStore'
 
 const store = usePriceStore()
 const lineRef = ref<HTMLDivElement|null>(null)

--- a/src/components/price/ReportListPanel.vue
+++ b/src/components/price/ReportListPanel.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="fixed inset-0 bg-black/40 flex justify-end z-50" @click.self="$emit('close')">
+    <aside class="bg-gray-900 text-white w-[90%] max-w-md h-full p-4">
+      <header class="flex justify-between mb-3">
+        <strong>저장된 보고서</strong>
+        <div class="flex gap-2">
+          <button class="bg-gray-700 px-2 py-1 rounded" @click="gen('daily')">일일</button>
+          <button class="bg-gray-700 px-2 py-1 rounded" @click="gen('weekly')">주간</button>
+          <button class="text-gray-400" @click="$emit('close')">✕</button>
+        </div>
+      </header>
+      <ul class="space-y-2">
+        <li v-for="r in store.reports" :key="r.id" class="flex justify-between items-center bg-gray-800 p-2 rounded">
+          <span>{{ r.date }} · {{ r.type==='daily'?'일일':'주간' }}</span>
+          <a v-if="r.url" :href="r.url" target="_blank" class="text-blue-400">다운로드</a>
+        </li>
+      </ul>
+    </aside>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePriceStore } from '@/stores/priceStore'
+const store = usePriceStore()
+async function gen(type:'daily'|'weekly'){ await store.saveReport(type) }
+</script>

--- a/src/components/price/ReportListPanel.vue
+++ b/src/components/price/ReportListPanel.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { usePriceStore } from '@/stores/priceStore'
+import { usePriceStore } from '../../stores/priceStore'
 const store = usePriceStore()
 async function gen(type:'daily'|'weekly'){ await store.saveReport(type) }
 </script>

--- a/src/components/price/ReportsFAB.vue
+++ b/src/components/price/ReportsFAB.vue
@@ -1,0 +1,11 @@
+<template>
+  <button class="fixed bottom-4 right-4 w-14 h-14 rounded-full bg-gray-900 text-white flex items-center justify-center text-xl shadow-lg z-40"
+    @click="open=true">📄</button>
+  <ReportListPanel v-if="open" @close="open=false"/>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import ReportListPanel from './ReportListPanel.vue'
+const open = ref(false)
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,6 +17,9 @@ import ProfileEdit from './components/ProfileEdit.vue'
 import DailyReports from './components/DailyReports.vue'
 import IntegrationsManager from './components/IntegrationsManager.vue'
 import LanguagePicker from './components/LanguagePicker.vue'
+// 기경: 아래에 새로 작성한 컴포넌트 import 수정함
+import PriceFeatureEntry from './components/price/PriceFeatureEntry.vue'
+
 
 const routes = [
   {
@@ -83,6 +86,11 @@ const routes = [
     path: '/price',
     name: 'PriceForecast',
     component: PriceForecast,
+  },
+  {
+    path: '/price-feature', // 기경: 새 라우트 추가
+    name: 'PriceFeatureEntry',
+    component: PriceFeatureEntry,
   },
   {
     path: '/finance',

--- a/src/stores/priceStore.ts
+++ b/src/stores/priceStore.ts
@@ -1,55 +1,33 @@
-export type PricePoint = { date: string; value: number };
-export type Deal = { id:string; market:string; item:string; unit:string; price:number; discountPct?:number; distanceKm?:number };
+import { defineStore } from 'pinia'
+import { priceService } from '@/utils/priceService'
+import type { Deal, PricePoint } from '@/utils/priceService'
 
-const delay = (ms:number)=> new Promise(r=>setTimeout(r, ms));
-
-export const priceService = {
-  async getWeeklyTrend(): Promise<PricePoint[]> {
-    await delay(200);
-    const base = 3200;
-    return Array.from({length:14}, (_,i)=>({
-      date: new Date(Date.now()-(13-i)*86400000).toISOString().slice(5,10),
-      value: Math.round(base + Math.sin(i/2)*120 + (Math.random()*60-30))
-    }));
-  },
-  async getYoYBars(): Promise<{ name:string; value:number }[]> {
-    await delay(120);
-    const current = 3150 + Math.round(Math.random()*120);
-    const lastYear = 3350 + Math.round(Math.random()*120);
-    return [{name:'작년', value:lastYear},{name:'현재', value:current}];
-  },
-  async getBestDeals(): Promise<Deal[]> {
-    await delay(150);
-    return [
-      { id:'d1', market:'이마트', item:'사과', unit:'1kg', price:4980, discountPct:18, distanceKm:1.2 },
-      { id:'d2', market:'홈플러스', item:'바나나', unit:'1kg', price:3980, discountPct:22, distanceKm:2.1 },
-    ];
-  },
-  async listSavedReports(): Promise<{id:string; date:string; type:'daily'|'weekly'; url?:string}[]> {
-    await delay(100);
-    const key = 'reports-demo';
-    const raw = localStorage.getItem(key);
-    if(raw) return JSON.parse(raw);
-    const seed = [{id:crypto.randomUUID(), date:'2025-09-29', type:'daily', url:'/sample.pdf'}];
-    localStorage.setItem(key, JSON.stringify(seed));
-    return seed;
-  },
-  async saveReport(type:'daily'|'weekly'){
-    await delay(300);
-    const key = 'reports-demo';
-    const list = await this.listSavedReports();
-    const item = {id:crypto.randomUUID(), date:new Date().toISOString().slice(0,10), type, url:'/sample.pdf'};
-    const next = [item, ...list];
-    localStorage.setItem(key, JSON.stringify(next));
-    return next;
-  },
-  async askLLMReason(deal: Deal){
-    await delay(400);
-    // 실제론 GPT/Gemini API 호출 위치
-    return `**추천 이유**
-- 가격: ${deal.price.toLocaleString()}원 (${deal.discountPct || 0}% 할인)
-- 거리: 약 ${deal.distanceKm ?? 1.5}km
-- 영양: 비타민C 충족, 당일 섭취량 기준 적정
-- 예산 내 최저가이며 현재 수요 대비 재고 충분`;
+export const usePriceStore = defineStore('price', {
+  state: () => ({
+    weekly: [] as PricePoint[],
+    yoy: [] as {name:string; value:number}[],
+    deals: [] as Deal[],
+    llmReason: '' as string,
+    selectedDeal: null as Deal | null,
+    reports: [] as {id:string; date:string; type:'daily'|'weekly'; url?:string}[],
+    loading: false,
+  }),
+  actions: {
+    async bootstrap(){
+      this.loading = true;
+      [this.weekly, this.yoy, this.deals, this.reports] = await Promise.all([
+        priceService.getWeeklyTrend(),
+        priceService.getYoYBars(),
+        priceService.getBestDeals(),
+        priceService.listSavedReports()
+      ]);
+      this.loading = false;
+    },
+    async refreshLLM(deal: Deal){
+      this.llmReason = await priceService.askLLMReason(deal);
+    },
+    async saveReport(type:'daily'|'weekly'){
+      this.reports = await priceService.saveReport(type);
+    }
   }
-};
+})

--- a/src/stores/priceStore.ts
+++ b/src/stores/priceStore.ts
@@ -1,0 +1,55 @@
+export type PricePoint = { date: string; value: number };
+export type Deal = { id:string; market:string; item:string; unit:string; price:number; discountPct?:number; distanceKm?:number };
+
+const delay = (ms:number)=> new Promise(r=>setTimeout(r, ms));
+
+export const priceService = {
+  async getWeeklyTrend(): Promise<PricePoint[]> {
+    await delay(200);
+    const base = 3200;
+    return Array.from({length:14}, (_,i)=>({
+      date: new Date(Date.now()-(13-i)*86400000).toISOString().slice(5,10),
+      value: Math.round(base + Math.sin(i/2)*120 + (Math.random()*60-30))
+    }));
+  },
+  async getYoYBars(): Promise<{ name:string; value:number }[]> {
+    await delay(120);
+    const current = 3150 + Math.round(Math.random()*120);
+    const lastYear = 3350 + Math.round(Math.random()*120);
+    return [{name:'작년', value:lastYear},{name:'현재', value:current}];
+  },
+  async getBestDeals(): Promise<Deal[]> {
+    await delay(150);
+    return [
+      { id:'d1', market:'이마트', item:'사과', unit:'1kg', price:4980, discountPct:18, distanceKm:1.2 },
+      { id:'d2', market:'홈플러스', item:'바나나', unit:'1kg', price:3980, discountPct:22, distanceKm:2.1 },
+    ];
+  },
+  async listSavedReports(): Promise<{id:string; date:string; type:'daily'|'weekly'; url?:string}[]> {
+    await delay(100);
+    const key = 'reports-demo';
+    const raw = localStorage.getItem(key);
+    if(raw) return JSON.parse(raw);
+    const seed = [{id:crypto.randomUUID(), date:'2025-09-29', type:'daily', url:'/sample.pdf'}];
+    localStorage.setItem(key, JSON.stringify(seed));
+    return seed;
+  },
+  async saveReport(type:'daily'|'weekly'){
+    await delay(300);
+    const key = 'reports-demo';
+    const list = await this.listSavedReports();
+    const item = {id:crypto.randomUUID(), date:new Date().toISOString().slice(0,10), type, url:'/sample.pdf'};
+    const next = [item, ...list];
+    localStorage.setItem(key, JSON.stringify(next));
+    return next;
+  },
+  async askLLMReason(deal: Deal){
+    await delay(400);
+    // 실제론 GPT/Gemini API 호출 위치
+    return `**추천 이유**
+- 가격: ${deal.price.toLocaleString()}원 (${deal.discountPct || 0}% 할인)
+- 거리: 약 ${deal.distanceKm ?? 1.5}km
+- 영양: 비타민C 충족, 당일 섭취량 기준 적정
+- 예산 내 최저가이며 현재 수요 대비 재고 충분`;
+  }
+};

--- a/src/stores/priceStore.ts
+++ b/src/stores/priceStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { priceService } from '@/utils/priceService'
-import type { Deal, PricePoint } from '@/utils/priceService'
+import { priceService } from '../utils/priceService'
+import type { Deal, PricePoint } from '../utils/priceService'
 
 export const usePriceStore = defineStore('price', {
   state: () => ({

--- a/src/utils/priceService.ts
+++ b/src/utils/priceService.ts
@@ -1,0 +1,55 @@
+export type PricePoint = { date: string; value: number };
+export type Deal = { id:string; market:string; item:string; unit:string; price:number; discountPct?:number; distanceKm?:number };
+
+const delay = (ms:number)=> new Promise(r=>setTimeout(r, ms));
+
+export const priceService = {
+  async getWeeklyTrend(): Promise<PricePoint[]> {
+    await delay(200);
+    const base = 3200;
+    return Array.from({length:14}, (_,i)=>({
+      date: new Date(Date.now()-(13-i)*86400000).toISOString().slice(5,10),
+      value: Math.round(base + Math.sin(i/2)*120 + (Math.random()*60-30))
+    }));
+  },
+  async getYoYBars(): Promise<{ name:string; value:number }[]> {
+    await delay(120);
+    const current = 3150 + Math.round(Math.random()*120);
+    const lastYear = 3350 + Math.round(Math.random()*120);
+    return [{name:'작년', value:lastYear},{name:'현재', value:current}];
+  },
+  async getBestDeals(): Promise<Deal[]> {
+    await delay(150);
+    return [
+      { id:'d1', market:'이마트', item:'사과', unit:'1kg', price:4980, discountPct:18, distanceKm:1.2 },
+      { id:'d2', market:'홈플러스', item:'바나나', unit:'1kg', price:3980, discountPct:22, distanceKm:2.1 },
+    ];
+  },
+  async listSavedReports(): Promise<{id:string; date:string; type:'daily'|'weekly'; url?:string}[]> {
+    await delay(100);
+    const key = 'reports-demo';
+    const raw = localStorage.getItem(key);
+    if(raw) return JSON.parse(raw);
+    const seed = [{id:crypto.randomUUID(), date:'2025-09-29', type:'daily', url:'/sample.pdf'}];
+    localStorage.setItem(key, JSON.stringify(seed));
+    return seed;
+  },
+  async saveReport(type:'daily'|'weekly'){
+    await delay(300);
+    const key = 'reports-demo';
+    const list = await this.listSavedReports();
+    const item = {id:crypto.randomUUID(), date:new Date().toISOString().slice(0,10), type, url:'/sample.pdf'};
+    const next = [item, ...list];
+    localStorage.setItem(key, JSON.stringify(next));
+    return next;
+  },
+  async askLLMReason(deal: Deal){
+    await delay(400);
+    // 실제론 GPT/Gemini API 호출 위치
+    return `**추천 이유**
+- 가격: ${deal.price.toLocaleString()}원 (${deal.discountPct || 0}% 할인)
+- 거리: 약 ${deal.distanceKm ?? 1.5}km
+- 영양: 비타민C 충족, 당일 섭취량 기준 적정
+- 예산 내 최저가이며 현재 수요 대비 재고 충분`;
+  }
+};


### PR DESCRIPTION
### Changes
- Add /price-feature route to mount new price module
- Add weekly trend line chart + YoY bar chart
- Add sticky best-deal widget (yellow) and LLM reason modal (dummy for now)
- Add reports FAB with saved reports drawer
- Add Pinia store (priceStore.ts) and mock service (priceService.ts)
- Keep existing /price route (PriceForecast.vue) intact

### How to test
1) Open /price-feature
2) Scroll down → sticky yellow widget appears
3) Click "자세히" → LLM modal opens (dummy text)
4) Click 📄 FAB (bottom-right) → Saved reports panel opens
