### PR TITLE
feat(price, home): implement charts, sticky widget, llm modal and report fab

### DIFF
--- a/src/components/Main_home.vue
+++ b/src/components/Main_home.vue
@@ -51,6 +51,8 @@
 
     <!-- 하단 네비게이션 -->
     <BottomNav />
+    <!-- 기경: 추가한 FAB -->
+    <ReportFAB />
   </div>
 </template>
 
@@ -58,6 +60,7 @@
 import { useNavigation } from '../composables/useRouter'
 import { useAppStore } from '../stores/app'
 import BottomNav from './BottomNav.vue'
+import ReportFAB from './ReportFAB.vue' // 기경: 추가함
 
 const { goToCalendar, goToSideMenu } = useNavigation()
 const appStore = useAppStore()

--- a/src/components/PriceForecast.vue
+++ b/src/components/PriceForecast.vue
@@ -4,22 +4,25 @@
     <div class="header">
       <span class="back-btn" @click="goBack">← Back</span>
     </div>
-    
+
     <!-- 상단 제목 -->
     <h1 class="title">바나나 구매를<br />도와드릴게요</h1>
 
-    <!-- 막대 차트 카드 -->
+    <!-- 1) 주간 바나나 가격 변동 추이 (라인차트) -->
     <div class="card">
       <div class="chart-title">주간 바나나 가격 변동 추이</div>
-      <div class="bar-chart-placeholder">📊 Bar Chart Placeholder</div>
+      <!-- 기존 placeholder 대신 차트 컨테이너 -->
+      <div ref="weeklyRef" class="bar-chart-placeholder"></div>
     </div>
 
-    <!-- 곡선 차트 카드 -->
+    <!-- 2) 작년 대비 현재 가격 (막대차트) -->
     <div class="card">
       <div class="chart-title">작년 대비 현재 가격</div>
+      <!-- 상단 좌측 라벨은 현재가 표시 -->
       <div class="line-chart-placeholder">
-        <span class="label">5340원</span>
-        📈 Line Chart Placeholder
+        <span class="label">{{ formatWon(currentPrice) }}</span>
+        <!-- 실제 차트는 아래 div에 렌더 -->
+        <div ref="yoyRef" style="position:absolute; inset:0; border-radius:12px;"></div>
       </div>
     </div>
 
@@ -29,14 +32,90 @@
 </template>
 
 <script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import * as echarts from 'echarts'
 import { useRouter } from 'vue-router'
 import BottomNav from './BottomNav.vue'
 
 const router = useRouter()
+const goBack = () => router.go(-1)
 
-const goBack = () => {
-  router.go(-1)
+// 차트 컨테이너 ref
+const weeklyRef = ref(null)
+const yoyRef = ref(null)
+
+// 데이터 (더미) 생성
+const weekly = ref([])       // [{date, value}]
+const currentPrice = ref(0)  // 오늘가
+const lastYearPrice = ref(0) // 작년가(더미)
+
+// 포맷터
+const formatWon = (v) => `${(v || 0).toLocaleString()}원`
+
+let lineChart = null
+let barChart  = null
+
+function drawWeekly() {
+  if (!weeklyRef.value) return
+  lineChart = lineChart || echarts.init(weeklyRef.value)
+  lineChart.setOption({
+    grid: { left: 10, right: 8, top: 10, bottom: 22 },
+    tooltip: { trigger: 'axis' },
+    xAxis: { type: 'category', data: weekly.value.map(d => d.date) },
+    yAxis: { type: 'value' },
+    series: [{
+      type: 'line',
+      smooth: true,
+      areaStyle: {},
+      data: weekly.value.map(d => d.value)
+    }]
+  })
+  lineChart.resize()
 }
+
+function drawYoY() {
+  if (!yoyRef.value) return
+  barChart = barChart || echarts.init(yoyRef.value)
+  barChart.setOption({
+    grid: { left: 28, right: 8, top: 14, bottom: 28 },
+    tooltip: { trigger: 'axis' },
+    xAxis: { type: 'category', data: ['작년', '현재'] },
+    yAxis: { type: 'value' },
+    series: [{
+      type: 'bar',
+      data: [lastYearPrice.value, currentPrice.value],
+      barWidth: '40%'
+    }]
+  })
+  barChart.resize()
+}
+
+function handleResize() {
+  lineChart && lineChart.resize()
+  barChart && barChart.resize()
+}
+
+onMounted(() => {
+  // 최근 14일 더미 데이터
+  const base = 3500
+  weekly.value = Array.from({ length: 14 }, (_, i) => ({
+    date: new Date(Date.now() - (13 - i) * 86400000).toISOString().slice(5, 10),
+    value: Math.round(base + Math.sin(i / 2) * 120 + (Math.random() * 60 - 30))
+  }))
+  currentPrice.value = weekly.value[weekly.value.length - 1].value
+  // 작년가(더미) — 현재가에 ±200 정도 변동
+  lastYearPrice.value = Math.max(0, currentPrice.value + (Math.random() * 400 - 200))
+
+  drawWeekly()
+  drawYoY()
+  window.addEventListener('resize', handleResize)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
+  lineChart && lineChart.dispose()
+  barChart && barChart.dispose()
+})
 </script>
 
 <style scoped>
@@ -49,39 +128,18 @@ const goBack = () => {
   min-height: 100vh;
   box-sizing: border-box;
 }
-
 .header {
   display: flex;
   justify-content: flex-start;
   font-size: 14px;
   margin-bottom: 1rem;
 }
+.back-btn { color: #ffc107; cursor: pointer; }
+.title { font-size: 24px; font-weight: bold; margin-bottom: 1.5rem; line-height: 1.4; }
+.card { background-color: #1e2e36; border-radius: 20px; padding: 1rem; margin-bottom: 1.2rem; }
+.chart-title { font-size: 14px; color: #ccc; margin-bottom: 0.6rem; }
 
-.back-btn {
-  color: #ffc107;
-  cursor: pointer;
-}
-
-.title {
-  font-size: 24px;
-  font-weight: bold;
-  margin-bottom: 1.5rem;
-  line-height: 1.4;
-}
-
-.card {
-  background-color: #1e2e36;
-  border-radius: 20px;
-  padding: 1rem;
-  margin-bottom: 1.2rem;
-}
-
-.chart-title {
-  font-size: 14px;
-  color: #ccc;
-  margin-bottom: 0.6rem;
-}
-
+/* 기존 placeholder 스타일을 차트 컨테이너로 재사용 */
 .bar-chart-placeholder,
 .line-chart-placeholder {
   background-color: #263843;
@@ -95,7 +153,7 @@ const goBack = () => {
   position: relative;
 }
 
-/* price label */
+/* 현재가 라벨 */
 .line-chart-placeholder .label {
   position: absolute;
   top: 12px;
@@ -106,5 +164,6 @@ const goBack = () => {
   border-radius: 10px;
   font-size: 12px;
   font-weight: 600;
+  z-index: 1;
 }
 </style>

--- a/src/components/ReportFAB.vue
+++ b/src/components/ReportFAB.vue
@@ -1,0 +1,46 @@
+<template>
+  <button class="fab" @click="open=true">⚙️</button>
+  <div v-if="open" class="drawer" @click.self="open=false">
+    <aside class="panel">
+      <header class="head">
+        <strong>저장된 일일 보고서</strong>
+        <div class="g">
+          <button class="btn" @click="genDaily">일일 생성</button>
+          <button class="x" @click="open=false">✕</button>
+        </div>
+      </header>
+      <ul class="list">
+        <li v-for="r in reports" :key="r.id">
+          <span>{{ r.date }} · {{ r.type==='daily'?'일일':'주간' }}</span>
+          <a v-if="r.url" :href="r.url" target="_blank">다운로드</a>
+        </li>
+      </ul>
+    </aside>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+type Report = { id:string; date:string; type:'daily'|'weekly'; url?:string }
+const open = ref(false)
+const reports = ref<Report[]>([])
+const KEY = 'reports-demo'
+
+function load(){ reports.value = JSON.parse(localStorage.getItem(KEY) || '[]') }
+function save(list: Report[]){ localStorage.setItem(KEY, JSON.stringify(list)); load() }
+function genDaily(){
+  const next: Report = { id: crypto.randomUUID(), date: new Date().toISOString().slice(0,10), type:'daily', url:'/sample.pdf' }
+  save([next, ...reports.value])
+}
+onMounted(()=> load())
+</script>
+
+<style scoped>
+.fab{ position:fixed; right:16px; bottom:16px; width:56px; height:56px; border-radius:50%; background:#111827; color:#fff; font-size:22px; display:flex; align-items:center; justify-content:center; z-index:40 }
+.drawer{ position:fixed; inset:0; background:rgba(0,0,0,.35); display:flex; justify-content:flex-end; z-index:60 }
+.panel{ width:min(420px, 92vw); height:100%; background:#0b1220; color:#e5e7eb; padding:14px }
+.head{ display:flex; justify-content:space-between; align-items:center; margin-bottom:8px }
+.btn{ background:#1f2937; color:#fff; border-radius:10px; padding:6px 10px }
+.x{ color:#9ca3af; }
+.list li{ display:flex; justify-content:space-between; align-items:center; padding:8px; background:#0f172a; margin-bottom:6px; border-radius:6px }
+</style>


### PR DESCRIPTION
### 작업 내용
- /price
  - 주간 바나나 가격 변동 추이 (echarts line chart)
  - 작년 대비 현재 가격 (echarts bar chart)
  - 스크롤 시 최적 구매처 제안 위젯 → '가격할인' 클릭 시 LLM 모달 (dummy reason)
- /main_home
  - 우측 하단 ⚙️ FAB 추가
  - 저장된 일일 보고서 패널 (생성/목록/다운로드)

### 테스트 방법
1. /price 접속 → 상단 두 박스에 차트 렌더링 확인
2. 스크롤 → 노란 위젯 등장 → '가격할인' → 모달 출력
3. /main_home 접속 → 하단 설정2 버튼 → 보고서 패널 열기
